### PR TITLE
Reproduction of build issue with tracked-toolbox: Could not resolve "@ember/debug", etc

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { cached } from 'tracked-toolbox';
+
+export default class ApplicationController extends Controller {
+  @tracked firstName = 'Tom';
+  @tracked lastName = 'Dale';
+
+  @cached
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
 {{page-title "ViteApp"}}
 
-<Example @message={{this.model.message}} />
+<Example @message={{this.fullName}} />
 
 <WelcomePage />
 {{! Feel free to remove this! }}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "stylelint-config-standard": "^33.0.0",
     "stylelint-prettier": "^3.0.0",
     "tracked-built-ins": "^3.1.1",
+    "tracked-toolbox": "^2.0.0",
     "typescript": "^5.1.6",
     "vite": "^5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ devDependencies:
   tracked-built-ins:
     specifier: ^3.1.1
     version: 3.1.1
+  tracked-toolbox:
+    specifier: ^2.0.0
+    version: 2.0.0(@babel/core@7.22.15)(ember-source@5.1.2)
   typescript:
     specifier: ^5.1.6
     version: 5.2.2
@@ -11422,6 +11425,23 @@ packages:
       ember-cli-typescript: 5.2.1
       ember-tracked-storage-polyfill: 1.0.0
     transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /tracked-toolbox@2.0.0(@babel/core@7.22.15)(ember-source@5.1.2):
+    resolution: {integrity: sha512-adZtX+RGN6F+pWs/5JqVuDxLhuia4uhqmQp+UlUaxpykWjDFETtAdQR+LdDJiFPXFAXnS6FBqn/tnSLJQCm3Yw==}
+    engines: {node: 14.* || 16.* || >= 18}
+    peerDependencies:
+      ember-source: '*'
+    peerDependenciesMeta:
+      ember-source:
+        optional: true
+    dependencies:
+      '@embroider/addon-shim': 1.8.6
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.22.15)
+      ember-source: 5.1.2(@babel/core@7.22.15)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.88.2)
+    transitivePeerDependencies:
+      - '@babel/core'
       - supports-color
     dev: true
 


### PR DESCRIPTION
![image](https://github.com/mansona/ember-vite-app/assets/200884/6db79ac4-75db-4635-ad92-f4feb5c81c14)

```
✘ [ERROR] Could not resolve "@ember/debug"

    node_modules/.pnpm/tracked-toolbox@2.0.0_@babel+core@7.22.15_ember-source@5.1.2/node_modules/tracked-toolbox/dist/index.js:1:23:
      1 │ import { assert } from '@ember/debug';
        ╵                        ~~~~~~~~~~~~~~

  You can mark the path "@ember/debug" as external to exclude it from the bundle, which will remove
  this error.

✘ [ERROR] Could not resolve "@ember/object"

    node_modules/.pnpm/tracked-toolbox@2.0.0_@babel+core@7.22.15_ember-source@5.1.2/node_modules/tracked-toolbox/dist/index.js:2:20:
      2 │ import { get } from '@ember/object';
        ╵                     ~~~~~~~~~~~~~~~

  You can mark the path "@ember/object" as external to exclude it from the bundle, which will remove
  this error.

✘ [ERROR] Could not resolve "@glimmer/tracking/primitives/cache"

    node_modules/.pnpm/tracked-toolbox@2.0.0_@babel+core@7.22.15_ember-source@5.1.2/node_modules/tracked-toolbox/dist/index.js:4:38:
      4 │ import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
        ╵                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "@glimmer/tracking/primitives/cache" as external to exclude it from the
  bundle, which will remove this error.

3:41:23 PM [vite] error while updating dependencies:
Error: Build failed with 3 errors:
node_modules/.pnpm/tracked-toolbox@2.0.0_@babel+core@7.22.15_ember-source@5.1.2/node_modules/tracked-toolbox/dist/index.js:1:23: ERROR: Could not resolve "@ember/debug"
node_modules/.pnpm/tracked-toolbox@2.0.0_@babel+core@7.22.15_ember-source@5.1.2/node_modules/tracked-toolbox/dist/index.js:2:20: ERROR: Could not resolve "@ember/object"
node_modules/.pnpm/tracked-toolbox@2.0.0_@babel+core@7.22.15_ember-source@5.1.2/node_modules/tracked-toolbox/dist/index.js:4:38: ERROR: Could not resolve "@glimmer/tracking/primitives/cache"
    at failureErrorWithLog (/home/lolmaus/Code/mainmatter/mainmatter/ember-vite-app/node_modules/.pnpm/esbuild@0.18.20/node_modules/esbuild/lib/main.js:1649:15)
    at /home/lolmaus/Code/mainmatter/mainmatter/ember-vite-app/node_modules/.pnpm/esbuild@0.18.20/node_modules/esbuild/lib/main.js:1058:25
    at /home/lolmaus/Code/mainmatter/mainmatter/ember-vite-app/node_modules/.pnpm/esbuild@0.18.20/node_modules/esbuild/lib/main.js:1525:9
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
 ELIFECYCLE  Command failed with exit code 1.
```